### PR TITLE
お気に入り追加で有料放送を通知しない時警告メッセージを出す

### DIFF
--- a/nicoNewStreamRecorderKakkoKari/alart4.0/src/gui/addForm.cs
+++ b/nicoNewStreamRecorderKakkoKari/alart4.0/src/gui/addForm.cs
@@ -761,6 +761,10 @@ namespace namaichi
 			var selectI = memberOnlyCheckList.SelectedIndex;
 			if (selectI != e.Index) return;
 			try {
+				if (e.Index == 3 && e.NewValue == CheckState.Unchecked ||
+					e.Index == 0 && memberOnlyCheckList.GetItemChecked(0) == true) {
+					DialogResult result = MessageBox.Show("無料部分（チラ見せ）のある有料放送も通知されなくなります");
+				}
 				if (e.Index == 0) {
 					for (var i = 1; i < memberOnlyCheckList.Items.Count; i++) {
 						memberOnlyCheckList.SetItemChecked(i, e.NewValue == CheckState.Checked);


### PR DESCRIPTION
チャンネル放送の有料放送のことですが、重要なことを忘れてました。
有料放送では放送者が放送中に無料・有料を切替できるんで、「有料放送を通知しない」にすると**無料部分のある有料放送も全て録画されなくなる**ことを一応注意メッセージで出しておいた方が良いと思います。
お気に入りの追加・修正画面で有料放送を通知しないのチェックがオフになるタイミングで警告？メッセージ出すように修正してみました。

